### PR TITLE
Changed "label305/auja" to version "3.0.0-alpha2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "label305/auja": "3.0.0-alpha8",
+        "label305/auja": "3.0.0-alpha2",
         "illuminate/support": "5.0.*"
     },
     "require-dev": {


### PR DESCRIPTION
This change is to remove installation errors from composer. It's saying 
  - Installation request for label305/auja-laravel dev-dev -> satisfiable by label305/auja-laravel[dev-dev].
  - label305/auja-laravel dev-dev requires label305/auja 3.0.0-alpha8 -> no matching package found.