### PR TITLE
updated references to "mix.publish"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Because Auja uses both a library for the PHP backand and a library for [the Java
     elixir(function(mix) {
         mix
         // .sass('app.scss') // included in Laravel 5 but not manditory
-        .publish('auja/auja.min.js', 'public/js/vendor/auja.js')
-        .publish('auja/auja.css', 'public/css/vendor/auja.css')
-        .publish('trumbowyg/dist/ui/trumbowyg.min.css', 'public/css/vendor/trumbowyg.css')
-        .publish('Ionicons/css/ionicons.min.css', 'public/css/vendor/ionicons.css')
-        .publish('Ionicons/fonts/ionicons.ttf', 'public/css/fonts/ionicons.ttf')
-        .publish('Ionicons/fonts/ionicons.woff', 'public/css/fonts/ionicons.woff')
-        .publish('animate.css/animate.min.css', 'public/css/vendor/animate.css');
+        .copy('auja/auja.min.js', 'public/js/vendor/auja.js')
+        .copy('auja/auja.css', 'public/css/vendor/auja.css')
+        .copy('trumbowyg/dist/ui/trumbowyg.min.css', 'public/css/vendor/trumbowyg.css')
+        .copy('Ionicons/css/ionicons.min.css', 'public/css/vendor/ionicons.css')
+        .copy('Ionicons/fonts/ionicons.ttf', 'public/css/fonts/ionicons.ttf')
+        .copy('Ionicons/fonts/ionicons.woff', 'public/css/fonts/ionicons.woff')
+        .copy('animate.css/animate.min.css', 'public/css/vendor/animate.css');
     });
     ```
 


### PR DESCRIPTION
the "publish" function was replaced by "copy"

reference here: https://github.com/laravel/elixir/commit/b6d59b9f68978224064964a75a7639f95aa2eeee